### PR TITLE
feat: set tab group id to code

### DIFF
--- a/docs/reference/evaluation-api/using-the-evaluation-api.mdx
+++ b/docs/reference/evaluation-api/using-the-evaluation-api.mdx
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 
 Before you can start evaluating flags, you must set a provider. The provider is the translation layer between the evaluation API and the flag system you use.
 
-<Tabs>
+<Tabs groupId="code">
 <TabItem value="js" label="Typescript">
 
 ```ts
@@ -39,7 +39,7 @@ The OpenFeature client is a lightweight abstraction used to evaluate feature fla
 If your application is small, you may use a single client for your whole application. In larger applications it may be helpful to create multiple clients,
 each with different configuration to fit the needs of different sub-modules. Clients may also be created dynamically, per each HTTP request, for instance.
 
-<Tabs>
+<Tabs groupId="code">
 <TabItem value="js" label="Typescript">
 
 ```ts
@@ -63,7 +63,7 @@ Client client = api.getClient("my-app");
 The client can be used to do basic flag evluation, which simple returns flag values of a particular type. The default value must also be specified.
 In the case of any error during flag evaluation, the default value will be returned, so give consideration to your default values!
 
-<Tabs>
+<Tabs groupId="code">
 <TabItem value="js" label="Typescript">
 
 ```ts

--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -19,7 +19,7 @@ const featureList: FeatureItem[] = [
     title: 'Simple API',
     iconDefinition: faMugHot,
     description: (
-      <Tabs>
+      <Tabs groupId="code">
         <TabItem value="ts" label="TypeScript">
           <div>
             {/* prettier-ignore */}
@@ -67,7 +67,7 @@ value, err := client
     title: 'Flexible integration',
     iconDefinition: faGears,
     description: (
-      <Tabs>
+      <Tabs groupId="code">
         <TabItem value="ts" label="TypeScript">
           <div>
             {/* prettier-ignore */}
@@ -126,7 +126,7 @@ func (p MyFlagProvider) GetBooleanEvaluation(
     title: 'Powerful extensions',
     iconDefinition: faBolt,
     description: (
-      <Tabs>
+      <Tabs groupId="code">
         <TabItem value="ts" label="TypeScript">
           <div>
             {/* prettier-ignore */}


### PR DESCRIPTION
Setting the tab group id automatically updates the selection of all the tabs within the same group. It also saves the selection to local storage for future use.

Signed-off-by: Michael Beemer <michael.beemer@dynatrace.com>