### PR TITLE
chore: Update dotnet examples to be inline with spec 0.2.0

### DIFF
--- a/docs/reference/concepts/01-evaluation-api.mdx
+++ b/docs/reference/concepts/01-evaluation-api.mdx
@@ -131,6 +131,9 @@ var stringValue = await client.GetStringValue("stringFlag", "default");
 // get an integer value
 var intValue = await client.GetIntegerValue("intFlag", 1);
 
+// get an double value
+var doubleValue = await client.GetDoubleValue("doubleFlag", 1);
+
 // get an object value
 var objectValue = await client.GetObjectValue("objectFlag", MyObjectInstance);
 ```
@@ -199,7 +202,10 @@ var boolDetails = await client.GetBooleanDetails("boolFlag", false);
 var stringDetails = await client.GetStringDetails("stringFlag", "default");
 
 // get details of int evaluation
-var intDetails = await client.GetNumberDetails("intFlag", 1);
+var intDetails = await client.GetIntegerDetails("intFlag", 1);
+
+// get details of double evaluation
+var doubleDetails = await client.GetDoubleDetails("doubleFlag", 1);
 
 // get details of object evaluation
 var objectDetails = await client.GetObjectDetails("objectFlag", myObjectDefaultInstance);

--- a/docs/reference/concepts/02-provider.mdx
+++ b/docs/reference/concepts/02-provider.mdx
@@ -141,7 +141,7 @@ public class MyFeatureProvider implements FeatureProvider {
 using OpenFeature.SDK;
 using OpenFeature.SDK.Model;
 
-public class MyFeatureProvider : IFeatureProvider
+public class MyFeatureProvider : FeatureProvider
 {
     public static string Name => "My Feature Provider";
 
@@ -164,11 +164,18 @@ public class MyFeatureProvider : IFeatureProvider
         // code to resolve string details
     }
 
-    public Task<ResolutionDetails<int>> ResolveNumberValue(string flagKey, int defaultValue,
+    public Task<ResolutionDetails<int>> ResolveIntegerValue(string flagKey, int defaultValue,
         EvaluationContext context = null,
         FlagEvaluationOptions config = null)
     {
-        // code to resolve number details
+        // code to resolve integer details
+    }
+
+    public Task<ResolutionDetails<double>> ResolveDoubleValue(string flagKey, double defaultValue,
+        EvaluationContext context = null,
+        FlagEvaluationOptions config = null)
+    {
+        // code to resolve integer details
     }
 
     public Task<ResolutionDetails<T>> ResolveStructureValue<T>(string flagKey, T defaultValue,

--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -137,7 +137,7 @@ func (p MyFlagProvider) BooleanEvaluation(
         <TabItem value="csharp" label="C#">
           {/* prettier-ignore */}
           <CodeBlock className="language-csharp">{`
-public class MyFlagProvider : IFeatureProvider
+public class MyFlagProvider : FeatureProvider
 {
   //...
   public Task<ResolutionDetails<bool>> ResolveBooleanValue(


### PR DESCRIPTION
These changes need to be pushed one https://github.com/open-feature/dotnet-sdk/issues/36 has been pushed to nuget