### PR TITLE
style: fix syntax and style for TypeScript example

### DIFF
--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -28,10 +28,10 @@ import {
   openFeature
 } from '@openfeature/nodejs-sdk'
 
-const client = openfeature.getClient('my-client);
+const client = openfeature.getClient('my-client');
 
 const value = client
-  .getBooleanValue('new-look', false );
+  .getBooleanValue('new-look', false);
             `}</CodeBlock>
           </div>
         </TabItem>


### PR DESCRIPTION
The current example for getting started with TypeScript has a syntax issue (missing closing quotation). Also removed some white space since I was already in the example 🙂 