### PR TITLE
Add Dependabot and Kodiak

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,5 +14,6 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
-      - "automerge"
       - "javascript"
+      # Disabling automerge until the dependabot PRs are verified
+      # - "automerge"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "automerge"
+      - "javascript"

--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -1,0 +1,12 @@
+version = 1
+
+[merge]
+automerge_label = "automerge"
+
+[merge.automerge_dependencies]
+# auto merge all PRs opened by "dependabot" that are "minor" or "patch" version upgrades. "major" version upgrades will be ignored.
+versions = ["minor", "patch"]
+usernames = ["dependabot"]
+
+[approve]
+auto_approve_usernames = ["dependabot"]


### PR DESCRIPTION
Configured Dependabot to update dependencies daily. Kodiak has also been configured but will not automatically merge until an "automerge" tag is added to a PR. This can be done automatically by removing the commented line from the Dependabot config.

Signed-off-by: Michael Beemer <beeme1mr@users.noreply.github.com>