### PR TITLE
Fix link to validation hook for Go SDK

### DIFF
--- a/src/components/ServerTechnologiesFeatures/GoFeatures/index.tsx
+++ b/src/components/ServerTechnologiesFeatures/GoFeatures/index.tsx
@@ -55,7 +55,7 @@ export class GoFeatures extends React.Component {
           {
             title: 'Validation Hook',
             description: 'A hook which validates the result of flag evaluations',
-            href: 'https://github.com/open-feature/go-sdk-contrib/tree/main/hooks/open-telemetry',
+            href: 'https://github.com/open-feature/go-sdk-contrib/tree/main/hooks/validator',
             svg: CheckCircle
           }
         ]}


### PR DESCRIPTION
Validation Hook link for GoSDK was pointing to the OTel hook instead

Signed-off-by: Mark Phelps <209477+markphelps@users.noreply.github.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR

Fixes Validation Hook link for GoSDK that was previously pointing to the OTel hook instead

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1234523

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

