### PR TITLE
docs: add a bit more details on local eval

### DIFF
--- a/blog/06-02-2023-catering-to-the-client-side.md
+++ b/blog/06-02-2023-catering-to-the-client-side.md
@@ -129,7 +129,7 @@ class MyFlaggingProvider implements Provider {
   // triggered when `setEvaluationContext` is called
   onContextSet(EvaluationContext oldContext, EvaluationContext newContext): void {
     // here the provider can re-evaluate flags using the next evaluation context, updating any
-    // previously cached flag values
+    // previously cached flag values or updating rulesets
   }
   //...
 }

--- a/blog/06-02-2023-catering-to-the-client-side.md
+++ b/blog/06-02-2023-catering-to-the-client-side.md
@@ -28,13 +28,13 @@ In other cases, flags might be evaluated out-of-process (by a remote service or 
 Regardless, with  server-side flags we can assume that evaluating a feature flag is a _relatively_ fast operation, even in cases where evaluations take place out-of-process.
 
 This situation is quite different with client-side flags.
-In cases of local evaluation, a ruleset (or a collection of them) must be sent to the client, in bulk or piecemeal. In cases of remote evaluation, the client must contact a remote server with the relevant context and receive an evaluated result. 
+In cases of local evaluation, a ruleset (or a collection of them) must be sent to the client, in bulk or piecemeal. In cases of remote evaluation, the client must contact a remote server with the relevant context and receive an evaluated result.
 
 This means that a client-side systems require network calls. Unfortunately we should also anticipate the latency for such a call to be slow, particularly if our users are behind a spotty internet connection. In fact, with a native mobile app we have to handle a fully disconnected client.
 
 ### Locally-evaluated systems and initialization
 
-For systems wherein flags are evaluated locally, signalling readiness to the consuming application can be of particular importance. Until the ruleset governing flag evaluation is fetched, we can't guarantee accurate flag values for the given context. We need an API that supports events or other asynchronous mechanisms to communicate the state of the underlying system. 
+For systems wherein flags are evaluated locally, signalling readiness to the consuming application can be of particular importance. Until the ruleset governing flag evaluation is fetched, we can't guarantee accurate flag values for the given context. We need an API that supports events or other asynchronous mechanisms to communicate the state of the underlying system.
 
 ### Remotely-evaluated systems and eager evaluation
 


### PR DESCRIPTION
In addition to improvements to the APIs for remotely evaluated systems, recent spec additions also better-support locally-evaluation (readiness-events, onContextSet hook, etc)

I've tried to capture those here and highlight this alternative architecture.

@moredip This is your blog post, so please don't feel obligated to take any of this, I just wanted to put it out there because I had some time today!