### PR TITLE
feat: add five minutes to feature flags tutorial

### DIFF
--- a/docs/tutorials/five-minutes-to-feature-flags.md
+++ b/docs/tutorials/five-minutes-to-feature-flags.md
@@ -103,7 +103,7 @@ Connecting OpenFeature to one of these backends is very straightforward, but it 
 https://github.com/open-feature/five-minutes-to-feature-flags/blob/main/04_openfeature_with_provider.js
 ```
 
-This minimalist provider is exactly that - you give it a hard-coded set of feature flag values, and it provides those values via the OpenFeature SDK.
+This minimal provider is exactly that - you give it a hard-coded set of feature flag values, and it provides those values via the OpenFeature SDK.
 
 In our `FLAG_CONFIGURATION` above we’ve hard-coded that `with-cows` feature flag to true, which means that conditional predicate in our express app will now evaluate to true, which means that our service will now start providing bovine output. Start the server with `node 04_openfeature_with_provider.js` and test it out.
 

--- a/docs/tutorials/five-minutes-to-feature-flags.md
+++ b/docs/tutorials/five-minutes-to-feature-flags.md
@@ -1,0 +1,188 @@
+---
+sidebar_position: 1
+id: five-minutes-to-feature-flags
+title: Five Minutes to Feature Flags
+---
+We’re going to add feature flagging to a Node service in under five minutes using OpenFeature, the open, vendor-agnostic feature flagging SDK.
+
+We’ll be working with a simple [express][express] server, but if you're familiar with JavaScript and Node you should be able to follow along.
+
+## Setup
+
+Before we jump into the tutorial, let's quickly get everything setup. You'll need [Git](https://git-scm.com/) and [NodeJS](https://nodejs.org/) version 16 or newer. After that, run the following commands from your favorite terminal.
+
+```bash
+git clone https://github.com/open-feature/five-minutes-to-feature-flags.git &&
+  cd five-minutes-to-feature-flags &&
+  npm install
+```
+
+## Hello, world
+
+Here’s the service we’ll be working on:
+
+```js reference title="01_vanilla.js"
+https://github.com/open-feature/five-minutes-to-feature-flags/blob/main/01_vanilla.js
+```
+
+Pretty much the most basic express server you can imagine - a single endpoint at `/` that returns a plaintext “Hello, world!” response.
+
+Let's start the service by running `node 01_vanilla.js`. Now you can test to make sure it works:
+
+```bash
+$> curl http://localhost:3333
+Hello, world!
+```
+
+Yep, looks good! Go ahead and stop the server using `Ctrl` + `C` on Windows or `⌘` + `C` on a Mac.
+
+## With cows, please
+
+Let’s imagine that we’re adding a new, experimental feature to this hello world service. We’re going to upgrade the format of the server’s response, using [cowsay][cowsay]!
+
+However, we’re not 100% sure that this cowsay formatting is going to work out, so for now we’ll protect it behind a conditional:
+
+```js reference title="02_basic_flags.js"
+https://github.com/open-feature/five-minutes-to-feature-flags/blob/main/02_basic_flags.js
+```
+
+Now let's start the server with our basic flag configuration by running `node 02_basic_flags.js`. By default, the service continues to work exactly as it did before, but if we change `withCow` to `true` then the response comes in an exciting new format:
+
+:::tip
+
+A server restart is required for any changes to be applied.
+
+:::
+
+```bash
+$> curl http://localhost:3333
+ _______________
+< Hello, world! >
+ ---------------
+        \   ^__^
+         \  (oo)\_______
+            (__)\       )\/\
+                ||----w |
+                ||     ||
+```
+
+## The crudest flag
+
+That `withCow` boolean and its accompanying conditional check are a very basic feature flag - they let us hide an experimental or unfinished feature, but also easily switch the feature on while we’re building and testing it.
+
+## Introducing OpenFeature
+
+Managing these flags by changing hardcoded constants gets old fast though. A team that uses feature flags in any significant way soon reaches for a feature flagging framework. Let’s move in that direction by updating the service to use OpenFeature.
+
+```js reference title="03_openfeature.js"
+https://github.com/open-feature/five-minutes-to-feature-flags/blob/main/03_openfeature.js
+```
+
+We’ve imported the `@openfeature/js-sdk` NPM module, and used it to create an OpenFeature client called `featureFlags`. We then call `getBooleanValue` on that client to find out if the `with-cows` feature flag is true or false. Depending on what we get back we either show the new cow-based output, or the traditional plaintext format.
+
+Start the server with `node 03_openfeature.js`.
+
+```bash
+$> curl http://localhost:3333
+Hello, world!
+```
+
+:::note
+
+When we call `getBooleanValue` we also provide a default value of false. Since we haven’t configured the OpenFeature SDK with a _feature flag provider_ yet, it will always return that default value.
+
+:::
+
+## Configuring an OpenFeature Provider
+
+Without a feature flagging provider OpenFeature is pretty pointless - it’ll just return default values. Instead we want to connect our OpenFeature SDK to a full-fledged feature flagging system - a commercial product, an open-source system, or perhaps a custom internal system - so that it can provide flagging decisions from that system.
+
+Connecting OpenFeature to one of these backends is very straightforward, but it does require that we have an actual flagging framework set up. For now, let’s just configure a really, really simple provider that doesn’t need a backend:
+
+```js reference title="04_openfeature_with_provider.js"
+https://github.com/open-feature/five-minutes-to-feature-flags/blob/main/04_openfeature_with_provider.js
+```
+
+This minimalist provider is exactly that - you give it a hard-coded set of feature flag values, and it provides those values via the OpenFeature SDK.
+
+In our `FLAG_CONFIGURATION` above we’ve hard-coded that `with-cows` feature flag to true, which means that conditional predicate in our express app will now evaluate to true, which means that our service will now start providing bovine output. Start the server with `node 04_openfeature_with_provider.js` and test it out.
+
+```bash
+$> curl http://localhost:3333
+ _______________
+< Hello, world! >
+ ---------------
+        \   ^__^
+         \  (oo)\_______
+            (__)\       )\/\
+                ||----w |
+                ||     ||
+```
+
+If we changed that `with-cows` value to false, we’d see the more boring response:
+
+```bash
+$> curl http://localhost:3333
+Hello, world!
+```
+
+## Moving to a full feature-flagging system
+
+We’ve gotten started with OpenFeature using a very simple but extremely limited provider. The beauty of OpenFeature is that we can transition to a real feature-flagging system when we’re ready, without any change to how we evaluate flags. It’s as simple as configuring a different provider.
+
+**For example:**
+
+### CloudBees
+
+```js
+import { CloudbeesProvider } from 'cloudbees-openfeature-provider-node';
+
+const appKey = '[YOUR_APP_KEY]';
+OpenFeature.setProvider(await CloudbeesProvider.build(appKey));
+```
+
+### flagd
+
+```js
+import { FlagdProvider } from '@openfeature/flagd-provider';
+
+OpenFeature.setProvider(
+  new FlagdProvider({
+    host: '[FLAGD_HOST]',
+    port: 8013,
+  })
+);
+```
+
+### LaunchDarkly
+
+```js
+import { init } from 'launchdarkly-node-server-sdk';
+import { LaunchDarklyProvider } from '@launchdarkly/openfeature-node-server';
+
+const ldClient = init('[YOUR-SDK-KEY]');
+await ldClient.waitForInitialization();
+OpenFeature.setProvider(new LaunchDarklyProvider(ldClient));
+```
+
+### Split
+
+```js
+import { SplitFactory } from '@splitsoftware/splitio';
+import { OpenFeatureSplitProvider } from '@splitsoftware/openfeature-js-split-provider';
+
+const splitClient = SplitFactory({ core: { authorizationKey: '[YOUR_AUTH_KEY]' } }).client();
+OpenFeature.setProvider(new OpenFeatureSplitProvider({ splitClient }));
+```
+
+We can get started with feature flags with low investment and low risk, and once we’re ready, it’s just a few lines of code to transition to a full-featured, scalable backend.
+
+## Next steps
+
+To learn more about OpenFeature, check out the documentation [here](/docs/reference/intro). Specifically, you can read more about how the [evaluation API works](/docs/reference/concepts/evaluation-api/), what [tech stacks are supported](/docs/reference/technologies/), or read [more tutorials](/docs/category/getting-started/) about using OpenFeature in a variety of tech stacks.
+
+We strive to provide a welcoming, open community. If you have any questions - or just want to nerd out about feature flags - the `#OpenFeature` channel in the [CNCF Slack](cncf-slack) is the place for you.
+
+[express]: https://expressjs.com/
+[cowsay]: https://www.npmjs.com/package/cowsay
+[cncf-slack]: https://slack.cncf.io/

--- a/docs/tutorials/five-minutes-to-feature-flags.md
+++ b/docs/tutorials/five-minutes-to-feature-flags.md
@@ -12,8 +12,8 @@ We’ll be working with a simple [express][express] server, but if you're famili
 Before we jump into the tutorial, let's quickly get everything setup. You'll need [Git](https://git-scm.com/) and [NodeJS](https://nodejs.org/) version 16 or newer. After that, run the following commands from your favorite terminal.
 
 ```bash
-git clone https://github.com/open-feature/five-minutes-to-feature-flags.git &&
-  cd five-minutes-to-feature-flags &&
+git clone https://github.com/open-feature/five-minutes-to-feature-flags.git && \
+  cd five-minutes-to-feature-flags && \
   npm install
 ```
 

--- a/docs/tutorials/five-minutes-to-feature-flags.md
+++ b/docs/tutorials/five-minutes-to-feature-flags.md
@@ -44,14 +44,25 @@ app.listen(3333, () => {
 
 Pretty much the most basic express server you can imagine - a single endpoint at `/` that returns a plaintext “Hello, world!” response.
 
-Let's start the service by running `node 01_vanilla.js`. Now you can test to make sure it works:
+Let's start the service by running:
 
 ```bash
-$> curl http://localhost:3333
+node 01_vanilla.js
+```
+
+Now you can test to make sure it works by entering the following command into the terminal:
+
+```bash
+curl http://localhost:3333
+```
+
+The output should look like this:
+
+```disable-copy-button
 Hello, world!
 ```
 
-Yep, looks good! Go ahead and stop the server using `Ctrl` + `C`.
+Looks good! Go ahead and stop the server using `Ctrl` + `C`.
 
 ## With cows, please
 
@@ -87,17 +98,22 @@ app.listen(3333, () => {
 });
 ```
 
-Now let's start the server with our basic flag configuration by running `node 02_basic_flags.js`. By default, the service continues to work exactly as it did before, but if we change `withCow` to `true` then the response comes in an exciting new format:
-
-:::tip
-
-A server restart is required for any changes to be applied.
-
-:::
+Now let's start the server with our basic flag configuration by running:
 
 ```bash
-$> curl http://localhost:3333
- _______________
+node 02_basic_flags.js
+```
+
+By default, the service continues to work exactly as it did before, but if we change `withCow` to `true` then the response comes in an exciting new format. To try it out, enter the following command into the terminal:
+
+```bash
+curl http://localhost:3333
+```
+
+The output should look like this:
+
+```disable-copy-button
+_______________
 < Hello, world! >
  ---------------
         \   ^__^
@@ -152,10 +168,21 @@ app.listen(3333, () => {
 
 We’ve imported the `@openfeature/js-sdk` NPM module, and used it to create an OpenFeature client called `featureFlags`. We then call `getBooleanValue` on that client to find out if the `with-cows` feature flag is true or false. Depending on what we get back we either show the new cow-based output, or the traditional plaintext format.
 
-Start the server with `node 03_openfeature.js`.
+Start the server with:
 
 ```bash
-$> curl http://localhost:3333
+node 03_openfeature.js
+```
+
+Enter the following command into the terminal:
+
+```bash
+curl http://localhost:3333
+```
+
+The output should look like this:
+
+```disable-copy-button
 Hello, world!
 ```
 
@@ -211,10 +238,23 @@ app.listen(3333, () => {
 
 This minimalist provider is exactly that; you give it a hard-coded set of feature flag values, and it provides those values via the OpenFeature SDK.
 
-In our `FLAG_CONFIGURATION` above we’ve hard-coded that `with-cows` feature flag to true, which means that conditional predicate in our express app will now evaluate to true, which means that our service will now start providing bovine output. Start the server with `node 04_openfeature_with_provider.js` and test it out.
+In our `FLAG_CONFIGURATION` above we’ve hard-coded that `with-cows` feature flag to true, which means that conditional predicate in our express app will now evaluate to true, which means that our service will now start providing bovine output.
+
+Start the server with:
 
 ```bash
-$> curl http://localhost:3333
+node 04_openfeature_with_provider.js
+```
+
+Test it out by entering the following command into the terminal:
+
+```bash
+curl http://localhost:3333
+```
+
+The output should look like this:
+
+```disable-copy-button
  _______________
 < Hello, world! >
  ---------------
@@ -227,8 +267,15 @@ $> curl http://localhost:3333
 
 If we changed that `with-cows` value to false, we’d see the more boring response:
 
+Enter the following command into the terminal:
+
 ```bash
-$> curl http://localhost:3333
+curl http://localhost:3333
+```
+
+The output should look like this:
+
+```disable-copy-button
 Hello, world!
 ```
 

--- a/docs/tutorials/five-minutes-to-feature-flags.md
+++ b/docs/tutorials/five-minutes-to-feature-flags.md
@@ -34,7 +34,7 @@ $> curl http://localhost:3333
 Hello, world!
 ```
 
-Yep, looks good! Go ahead and stop the server using `Ctrl` + `C` on Windows or `⌘` + `C` on a Mac.
+Yep, looks good! Go ahead and stop the server using `Ctrl` + `C`.
 
 ## With cows, please
 
@@ -181,7 +181,7 @@ We can get started with feature flags with low investment and low risk, and once
 
 To learn more about OpenFeature, check out the documentation [here](/docs/reference/intro). Specifically, you can read more about how the [evaluation API works](/docs/reference/concepts/evaluation-api/), what [tech stacks are supported](/docs/reference/technologies/), or read [more tutorials](/docs/category/getting-started/) about using OpenFeature in a variety of tech stacks.
 
-We strive to provide a welcoming, open community. If you have any questions - or just want to nerd out about feature flags - the `#OpenFeature` channel in the [CNCF Slack](cncf-slack) is the place for you.
+We strive to provide a welcoming, open community. If you have any questions - or just want to nerd out about feature flags - the `#OpenFeature` channel in the [CNCF Slack][cncf-slack] is the place for you.
 
 [express]: https://expressjs.com/
 [cowsay]: https://www.npmjs.com/package/cowsay

--- a/docs/tutorials/five-minutes-to-feature-flags.md
+++ b/docs/tutorials/five-minutes-to-feature-flags.md
@@ -50,7 +50,7 @@ Let's start the service by running:
 node 01_vanilla.js
 ```
 
-Now you can test to make sure it works by entering the following command into the terminal:
+Now you can test to make sure it works by entering the following command into a second terminal:
 
 ```bash
 curl http://localhost:3333
@@ -104,7 +104,9 @@ Now let's start the server with our basic flag configuration by running:
 node 02_basic_flags.js
 ```
 
-By default, the service continues to work exactly as it did before, but if we change `withCow` to `true` then the response comes in an exciting new format. To try it out, enter the following command into the terminal:
+By default, the service continues to work exactly as it did before.
+
+Next change `withCow` to `true` using your favorite text editor and restart the node server. Now the response comes in an exciting new format. To try it out, enter the following command into the terminal:
 
 ```bash
 curl http://localhost:3333
@@ -265,9 +267,7 @@ The output should look like this:
                 ||     ||
 ```
 
-If we changed that `with-cows` value to false, we’d see the more boring response:
-
-Enter the following command into the terminal:
+Next change the `with-cows` value to false and restart the node server. We will now see the more boring response when entering the following command into the terminal:
 
 ```bash
 curl http://localhost:3333

--- a/docs/tutorials/getting-started/_category_.json
+++ b/docs/tutorials/getting-started/_category_.json
@@ -1,11 +1,11 @@
 {
-  "position": 1,
+  "position": 2,
   "label": "Getting Started",
   "collapsible": true,
   "collapsed": false,
   "link": {
     "type": "generated-index",
     "title": "Getting started with the OpenFeature SDK",
-    "description": "These step-by-step guides walk you through the basics of the OpenFeature SDK for your preferred language, using flagd as a backend."
+    "description": "These step-by-step guides walk you through the basics of the OpenFeature SDK for your preferred language."
   }
 }

--- a/docs/tutorials/getting-started/node.mdx
+++ b/docs/tutorials/getting-started/node.mdx
@@ -197,7 +197,7 @@ If all goes as planned, you should see "Express + TypeScript Server" in glorious
 
 <WhyDefaultContent />
 
-> NOTE: You should stop the app by using the keyboard short `ctrl + c` or `⌘ + c` before moving on to the next step.
+> NOTE: You should stop the app by using the keyboard short `ctrl + c` before moving on to the next step.
 
 ### Step 5: Configure a provider (flagd)
 

--- a/docs/tutorials/ofo.md
+++ b/docs/tutorials/ofo.md
@@ -1,10 +1,10 @@
 ---
 sidebar_position: 2
 id: ofo
-title: Cloud native flags with the OpenFeature Operator
+title: Cloud Native Flags with the OpenFeature Operator
 ---
 
-# Cloud native feature-flagging with the OpenFeature Operator
+# Cloud Native Feature-Flagging with the OpenFeature Operator
 
 In the following tutorial, we'll see how to leverage _flagd_ and the OpenFeature Operator to enable cloud-native, self-hosted feature flags in your Kubernetes cluster. [flagd](https://github.com/open-feature/flagd) is a "feature flag daemon with a Unix philosophy".
 Put another way, it's a small, self-contained binary that evaluates feature flags, uses standard interfaces, and runs just about anywhere.
@@ -43,7 +43,9 @@ If you already have a K8s cluster, you can skip to [Install cert-manager](#insta
 ##### Using Kind
 
 Download the cluster definition file, `kind-cluster.yaml`:
+
 <!-- TODO: update this before merge to point to asset in main -->
+
 ```shell
 curl -sfL curl -sfL https://raw.githubusercontent.com/open-feature/docs.openfeature.dev/main/static/samples/kind-cluster.yaml > kind-cluster.yaml
 ```

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,7 +1,6 @@
 // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
-
-const lightCodeTheme = require('prism-react-renderer/themes/nightOwlLight');
+const oceanicCodeTheme = require('prism-react-renderer/themes/oceanicNext');
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -167,6 +166,7 @@ const config = {
     ],
     'docusaurus-plugin-sass',
   ],
+  themes: ['docusaurus-theme-github-codeblock'],
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
@@ -201,7 +201,7 @@ const config = {
           },
           {
             type: 'doc',
-            docId: '/category/getting-started',
+            docId: 'tutorials/five-minutes-to-feature-flags',
             position: 'left',
             label: 'Tutorials',
           },
@@ -234,7 +234,7 @@ const config = {
               },
               {
                 label: 'Tutorials',
-                to: 'docs/category/getting-started',
+                to: 'docs/tutorials/five-minutes-to-feature-flags',
               },
             ],
           },
@@ -283,8 +283,14 @@ const config = {
         copyright: `© ${new Date().getFullYear()} OpenFeature is a Cloud Native Computing Foundation sandbox project | Documentation Distributed under CC BY 4.0 | All Rights Reserved`,
       },
       prism: {
-        theme: lightCodeTheme,
-        additionalLanguages: ['typescript', 'go', 'java', 'csharp', 'powershell', 'php'],
+        theme: oceanicCodeTheme,
+        additionalLanguages: ['java', 'csharp', 'powershell', 'php'],
+      },
+      codeblock: {
+        showGithubLink: true,
+        githubLinkLabel: 'View on GitHub',
+        showRunmeLink: false,
+        runmeLinkLabel: 'Checkout via Runme',
       },
       algolia: {
         appId: 'PH0VDWFP7Q',
@@ -293,7 +299,6 @@ const config = {
         contextualSearch: true,
       },
     }),
-
 };
 
 module.exports = config;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@mdx-js/react": "1.6.22",
     "clsx": "1.2.1",
     "docusaurus-plugin-sass": "^0.2.3",
+    "docusaurus-theme-github-codeblock": "^1.1.4",
     "mdx-mermaid": "1.3.2",
     "mermaid": "10.1.0",
     "prism-react-renderer": "1.3.5",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -56,3 +56,12 @@
   background-color: white !important;
   border-radius: var(--ifm-global-radius);
 }
+/**
+* Disables the copy button on a code block if the language is
+* set to 'disable-copy-button'.
+* 
+* @link https://stackoverflow.com/questions/70739852/docosaurus-how-can-you-hide-copy-button-next-to-the-code-example
+*/
+.language-disable-copy-button button {
+  display: none !important;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1575,7 +1575,7 @@
     fs-extra "^10.1.0"
     tslib "^2.4.0"
 
-"@docusaurus/types@2.4.0":
+"@docusaurus/types@2.4.0", "@docusaurus/types@^2.3.1":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@docusaurus/types/-/types-2.4.0.tgz#f94f89a0253778b617c5d40ac6f16b17ec55ce41"
   integrity sha512-xaBXr+KIPDkIaef06c+i2HeTqVNixB7yFut5fBXPGI2f1rrmEV2vLMznNGsFwvZ5XmA3Quuefd4OGRkdo97Dhw==
@@ -4121,6 +4121,13 @@ docusaurus-plugin-sass@^0.2.3:
   integrity sha512-FbaE06K8NF8SPUYTwiG+83/jkXrwHJ/Afjqz3SUIGon6QvFwSSoKOcoxGQmUBnjTOk+deUONDx8jNWsegFJcBQ==
   dependencies:
     sass-loader "^10.1.1"
+
+docusaurus-theme-github-codeblock@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/docusaurus-theme-github-codeblock/-/docusaurus-theme-github-codeblock-1.1.4.tgz#98ff4f27603da25169c9b60c8fe3124d9a002841"
+  integrity sha512-a8sBUHTpbXBg8qS8H43VogRusOrY4aqpVYs6RiA08lQqI5FxYjAVGMArHQD/Rz0mYm3h/iiqgsVc3K4lTaIt3A==
+  dependencies:
+    "@docusaurus/types" "^2.3.1"
 
 dom-converter@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
## This PR

- adds a new tutorial called Five Minutes to Feature Flags

### Notes

Special thanks to @moredip for writing the [original blog](https://blog.thepete.net/blog/2023/03/02/five-minutes-to-feature-flags/). 🙇‍♂️ 

### Follow-up Tasks

- Update the new landing page to point to this tutorial
- Update the [five minutes to feature flags repo](https://github.com/open-feature/five-minutes-to-feature-flags) to include a link to the docs
