### PR TITLE
add deprecation warning and Netlify redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # OpenFeature Documentation
 
-This repository provides the documentation for OpenFeature; including the SDK, flagd and the operator.
+This repository provides the documentation for OpenFeature.
+
+> :warning: **The docs have moved!**: You can find the new docs [here](https://github.com/open-feature/openfeature.dev).
 
 ## Documentation Structure
 

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,2 @@
+http://docs.openfeature.dev/* https://openfeature.dev/:splat 301!
+https://docs.openfeature.dev/* https://openfeature.dev/:splat 301!


### PR DESCRIPTION
## This PR

- add a deprecation warning to the readme
- sets up a permanent redirect to from docs.openfeature.dev to openfeature.dev
